### PR TITLE
Adds a password to return to validate local setup

### DIFF
--- a/get_password.py
+++ b/get_password.py
@@ -1,0 +1,14 @@
+import os
+from dotenv import load_dotenv
+from app.mongo_files.database import MongoDB
+
+
+def get_password():
+    load_dotenv()
+    db = MongoDB()
+    password = db.read(os.getenv("MONGO_COLLECTION"))[0][os.getenv("MONGO_FIELD")]
+    print(password)
+
+
+if __name__ == '__main__':
+    get_password()


### PR DESCRIPTION
## Description

Adds an easier way to retrieve the password needed for Canvas's Module 1 CFU without spinning up the whole Mongo-based API, just run `get_password.py` and if the environment variables are correct, a password prints. 

## Type of change

- [x] Bug fix

## Checklist:

- [x] My code follows PEP8 style guide
- [x] I have removed unnecessary print statements from my code
- [x] I have made corresponding changes to the documentation if necessary
- [x] My changes generate no errors
- [x] No commented-out code
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes
